### PR TITLE
Test for passwords containing `#` characters

### DIFF
--- a/examples/octothorpe.netrc
+++ b/examples/octothorpe.netrc
@@ -1,0 +1,4 @@
+# Octothorpes should be allowed in passwords.
+machine hash
+  login joecool@example.com
+  password foo#bar$baz%boom

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -137,6 +137,14 @@ func (s *NetrcSuite) TestPassword(c *C) {
 	c.Check(f.Render(), Equals, string(body))
 }
 
+func (s *NetrcSuite) TestGetOctothorpe(c *C) {
+	f, err := netrc.Parse("./examples/octothorpe.netrc")
+	c.Assert(err, IsNil)
+	c.Check(f.Machine("hash").Get("password"), Equals, "foo#bar$baz%boom")
+	body, _ := ioutil.ReadFile(f.Path)
+	c.Check(f.Render(), Equals, string(body))
+}
+
 func (s *NetrcSuite) TestPermissive(c *C) {
 	f, err := netrc.Parse("./examples/permissive.netrc")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Passwords needs to allow all kinds of weird characters.

This test addresses issue #2 as well as `#` characters.
