### PR TITLE
Add support for parsing a string

### DIFF
--- a/netrc.go
+++ b/netrc.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"unicode"
 )
 
@@ -47,6 +48,17 @@ func Parse(path string) (*Netrc, error) {
 		return nil, err
 	}
 	netrc.Path = path
+	return netrc, nil
+}
+
+// ParseString behaves just like Parse, but can be used to parse netrc data
+// without loading it from a file.
+func ParseString(contents string) (*Netrc, error) {
+	r := strings.NewReader(contents)
+	netrc, err := parse(lex(r))
+	if err != nil {
+		return nil, err
+	}
 	return netrc, nil
 }
 

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -1,6 +1,7 @@
 package netrc_test
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -161,4 +162,16 @@ func (s *NetrcSuite) TestPermissive(c *C) {
 	c.Check(f.Machine("m").Get("password"), Equals, "p")
 	body, _ := ioutil.ReadFile(f.Path)
 	c.Check(f.Render(), Equals, string(body))
+}
+
+func (s *NetrcSuite) TestParseString(c *C) {
+	file, err := os.Open("./examples/good.netrc")
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	c.Assert(err, IsNil)
+	f, err := netrc.ParseString(string(data))
+	c.Assert(err, IsNil)
+	c.Check(f.Machine("mail.google.com").Get("login"), Equals, "joe@gmail.com")
+	c.Check(f.Machine("mail.google.com").Get("account"), Equals, "justagmail")
+	c.Check(f.Machine("mail.google.com").Get("password"), Equals, "somethingSecret")
 }


### PR DESCRIPTION
Thanks for the helpful package! 

This PR adds a `ParseString` function that allows one to directly parse netrc content.