### PR TITLE
fix: prevent missing newline when adding machine to file

### DIFF
--- a/netrc.go
+++ b/netrc.go
@@ -277,15 +277,42 @@ func (m *Machine) Set(name, value string) {
 		}
 		i = i + 4
 	}
+	indent := detectIndent(m.tokens)
+	separator := "\n" + indent
 	if n := len(m.tokens); n > 0 {
 		last := m.tokens[n-1]
-		if !strings.HasSuffix(last, "  ") {
+		if !strings.HasSuffix(last, separator) {
 			if strings.HasSuffix(last, "\n") {
-				m.tokens[n-1] = last + "  "
+				m.tokens[n-1] = last + indent
 			} else {
-				m.tokens[n-1] = last + "\n  "
+				m.tokens = append(m.tokens, separator)
 			}
 		}
 	}
 	m.tokens = append(m.tokens, name, " ", value, "\n")
+}
+
+// detectIndent returns the indent string used after newlines in the given
+// tokens. It looks for the substring after the last "\n" in any token; if
+// that substring is non-empty and entirely whitespace, it's treated as the
+// file's indent style. Falls back to two spaces when nothing is detected.
+func detectIndent(tokens []string) string {
+	for _, tok := range tokens {
+		idx := strings.LastIndex(tok, "\n")
+		if idx < 0 || idx == len(tok)-1 {
+			continue
+		}
+		candidate := tok[idx+1:]
+		allWhitespace := true
+		for _, r := range candidate {
+			if !unicode.IsSpace(r) {
+				allWhitespace = false
+				break
+			}
+		}
+		if allWhitespace {
+			return candidate
+		}
+	}
+	return "  "
 }

--- a/netrc.go
+++ b/netrc.go
@@ -83,13 +83,30 @@ func (n *Netrc) Machine(name string) *Machine {
 func (n *Netrc) AddMachine(name, login, password string) {
 	machine := n.Machine(name)
 	if machine == nil {
+		n.ensureTrailingNewline()
 		machine = &Machine{}
 		n.machines = append(n.machines, machine)
 	}
 	machine.Name = name
-	machine.tokens = []string{"machine ", name, "\n"}
+	machine.tokens = []string{"machine", " ", name, "\n"}
 	machine.Set("login", login)
 	machine.Set("password", password)
+}
+
+// ensureTrailingNewline guarantees the most recent token ends with "\n"
+// so that a newly appended machine starts on its own line.
+func (n *Netrc) ensureTrailingNewline() {
+	tokens := &n.tokens
+	if len(n.machines) > 0 {
+		tokens = &n.machines[len(n.machines)-1].tokens
+	}
+	if len(*tokens) == 0 {
+		return
+	}
+	last := (*tokens)[len(*tokens)-1]
+	if !strings.HasSuffix(last, "\n") {
+		*tokens = append(*tokens, "\n")
+	}
 }
 
 // RemoveMachine remove a machine
@@ -260,5 +277,15 @@ func (m *Machine) Set(name, value string) {
 		}
 		i = i + 4
 	}
-	m.tokens = append(m.tokens, "  ", name, " ", value, "\n")
+	if n := len(m.tokens); n > 0 {
+		last := m.tokens[n-1]
+		if !strings.HasSuffix(last, "  ") {
+			if strings.HasSuffix(last, "\n") {
+				m.tokens[n-1] = last + "  "
+			} else {
+				m.tokens[n-1] = last + "\n  "
+			}
+		}
+	}
+	m.tokens = append(m.tokens, name, " ", value, "\n")
 }

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -108,6 +108,25 @@ func (s *NetrcSuite) TestNewlineless(c *C) {
 	c.Check(f.Render(), Equals, string(body))
 }
 
+func (s *NetrcSuite) TestAddToNewlineless(c *C) {
+	f, err := netrc.Parse("./examples/newlineless.netrc")
+	c.Assert(err, IsNil)
+	f.AddMachine("m2", "l2", "p2")
+	c.Check(f.Render(), Equals, "# this is my netrc\nmachine m\n  login l # this is my username\n  password p\n"+
+		"machine m2\n  login l2\n  password p2\n")
+	c.Check(f.Machine("m").Get("password"), Equals, "p")
+	c.Check(f.Machine("m2").Get("password"), Equals, "p2")
+}
+
+func (s *NetrcSuite) TestAddToParseStringWithoutTrailingNewline(c *C) {
+	sample := "machine example.com\nlogin user\npassword pass"
+	f, err := netrc.ParseString(sample)
+	c.Assert(err, IsNil)
+	f.AddMachine("example2.com", "hello", "world")
+	c.Check(f.Render(), Equals, "machine example.com\nlogin user\npassword pass\n"+
+		"machine example2.com\n  login hello\n  password world\n")
+}
+
 func (s *NetrcSuite) TestBadDefaultOrder(c *C) {
 	f, err := netrc.Parse("./examples/bad_default_order.netrc")
 	c.Assert(err, IsNil)

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -127,6 +127,35 @@ func (s *NetrcSuite) TestAddToParseStringWithoutTrailingNewline(c *C) {
 		"machine example2.com\n  login hello\n  password world\n")
 }
 
+func (s *NetrcSuite) TestSetNewPropertyOnNewlineless(c *C) {
+	f, err := netrc.ParseString("machine m\nlogin l\npassword p")
+	c.Assert(err, IsNil)
+	m := f.Machine("m")
+	m.Set("account", "acct")
+	c.Check(m.Get("login"), Equals, "l")
+	c.Check(m.Get("password"), Equals, "p")
+	c.Check(m.Get("account"), Equals, "acct")
+	c.Check(f.Render(), Equals, "machine m\nlogin l\npassword p\n  account acct\n")
+}
+
+func (s *NetrcSuite) TestSetPreservesTabIndent(c *C) {
+	f, err := netrc.ParseString("machine m\n\tlogin l\n\tpassword p\n")
+	c.Assert(err, IsNil)
+	m := f.Machine("m")
+	m.Set("account", "acct")
+	c.Check(m.Get("account"), Equals, "acct")
+	c.Check(f.Render(), Equals, "machine m\n\tlogin l\n\tpassword p\n\taccount acct\n")
+}
+
+func (s *NetrcSuite) TestSetPreservesFourSpaceIndent(c *C) {
+	f, err := netrc.ParseString("machine m\n    login l\n    password p\n")
+	c.Assert(err, IsNil)
+	m := f.Machine("m")
+	m.Set("account", "acct")
+	c.Check(m.Get("account"), Equals, "acct")
+	c.Check(f.Render(), Equals, "machine m\n    login l\n    password p\n    account acct\n")
+}
+
 func (s *NetrcSuite) TestBadDefaultOrder(c *C) {
 	f, err := netrc.Parse("./examples/bad_default_order.netrc")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Calling AddMachine on a parsed netrc whose source content does not end with a newline previously produced output where the new machine ran into the prior entry. AddMachine now ensures the preceding tokens end with a newline before appending. The token layout for newly added machines was also aligned with the parsed format so that Get on a freshly added machine returns the values that were set.

Closes #14