### PR TITLE
fix: handle standalone comment lines in Get and Set

### DIFF
--- a/examples/comments.netrc
+++ b/examples/comments.netrc
@@ -1,0 +1,10 @@
+# top of file comment
+machine m
+  # comment before any property
+  login l
+  # comment between properties
+  password p
+machine n
+  login ln
+  # comment between properties
+  password pn

--- a/netrc.go
+++ b/netrc.go
@@ -252,19 +252,33 @@ func (m *Machine) Set(name, value string) {
 }
 
 // isWhitespaceOrComment reports whether a token contributes only formatting,
-// either pure whitespace or a comment. Tokens whose first non-whitespace
-// rune is '#' are comments; value tokens that contain '#' mid-string (e.g.
-// "foo#bar") return false because their first rune is non-whitespace.
+// either pure whitespace or a lexer-produced comment. Lexer comment tokens
+// always have leading whitespace (trailing comment) or contain a newline
+// (leading comment terminated by newline). Programmatic value tokens whose
+// first rune is '#' (e.g. a password set to "#secret") have neither, so they
+// are not classified as comments.
 func isWhitespaceOrComment(s string) bool {
-	for _, r := range s {
-		if r == '#' {
-			return true
+	if s == "" {
+		return true
+	}
+	hashIdx := strings.IndexByte(s, '#')
+	if hashIdx == -1 {
+		for _, r := range s {
+			if !unicode.IsSpace(r) {
+				return false
+			}
 		}
+		return true
+	}
+	for _, r := range s[:hashIdx] {
 		if !unicode.IsSpace(r) {
 			return false
 		}
 	}
-	return true
+	if hashIdx > 0 {
+		return true
+	}
+	return strings.ContainsRune(s, '\n')
 }
 
 // findKey returns the index in m.tokens of the property key matching name,

--- a/netrc.go
+++ b/netrc.go
@@ -232,33 +232,82 @@ func parse(tokens []string) (*Netrc, error) {
 
 // Get a property from a machine
 func (m *Machine) Get(name string) string {
-	i := 4
-	if m.IsDefault {
-		i = 2
-	}
-	for {
-		if i+2 >= len(m.tokens) {
-			return ""
+	if k := m.findKey(name); k != -1 {
+		if v := m.findValueAfter(k); v != -1 {
+			return m.tokens[v]
 		}
-		if m.tokens[i] == name {
-			return m.tokens[i+2]
-		}
-		i = i + 4
 	}
+	return ""
 }
 
 // Set a property on the machine
 func (m *Machine) Set(name, value string) {
-	i := 4
-	if m.IsDefault {
-		i = 2
-	}
-	for i+2 < len(m.tokens) {
-		if m.tokens[i] == name {
-			m.tokens[i+2] = value
+	if k := m.findKey(name); k != -1 {
+		if v := m.findValueAfter(k); v != -1 {
+			m.tokens[v] = value
 			return
 		}
-		i = i + 4
 	}
 	m.tokens = append(m.tokens, "  ", name, " ", value, "\n")
+}
+
+// isWhitespaceOrComment reports whether a token contributes only formatting,
+// either pure whitespace or a comment. Tokens whose first non-whitespace
+// rune is '#' are comments; value tokens that contain '#' mid-string (e.g.
+// "foo#bar") return false because their first rune is non-whitespace.
+func isWhitespaceOrComment(s string) bool {
+	for _, r := range s {
+		if r == '#' {
+			return true
+		}
+		if !unicode.IsSpace(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// findKey returns the index in m.tokens of the property key matching name,
+// or -1 if not present. It skips the machine declaration ("machine <name>"
+// or "default") and any whitespace-or-comment tokens that may appear
+// between properties.
+func (m *Machine) findKey(name string) int {
+	skip := 2
+	if m.IsDefault {
+		skip = 1
+	}
+	start := len(m.tokens)
+	seen := 0
+	for i, t := range m.tokens {
+		if isWhitespaceOrComment(t) {
+			continue
+		}
+		seen++
+		if seen == skip {
+			start = i + 1
+			break
+		}
+	}
+	expectKey := true
+	for i := start; i < len(m.tokens); i++ {
+		if isWhitespaceOrComment(m.tokens[i]) {
+			continue
+		}
+		if expectKey && m.tokens[i] == name {
+			return i
+		}
+		expectKey = !expectKey
+	}
+	return -1
+}
+
+// findValueAfter returns the index of the value token that follows the key
+// at index k, skipping whitespace-or-comment tokens, or -1 if none.
+func (m *Machine) findValueAfter(k int) int {
+	for j := k + 1; j < len(m.tokens); j++ {
+		if !isWhitespaceOrComment(m.tokens[j]) {
+			return j
+		}
+	}
+	return -1
 }

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -182,8 +182,9 @@ func (s *NetrcSuite) TestSetWithCommentLines(c *C) {
 	f.Machine("m").Set("password", "newpw")
 	c.Check(f.Machine("m").Get("password"), Equals, "newpw")
 	rendered := f.Render()
-	c.Check(strings.Contains(rendered, "# comment before any property"), Equals, true)
-	c.Check(strings.Contains(rendered, "# comment between properties"), Equals, true)
+	c.Check(rendered, Equals, "# top of file comment\nmachine m\n  # comment before any property\n  login l\n  # comment between properties\n  password newpw\nmachine n\n  login ln\n  # comment between properties\n  password pn\n")
+	c.Check(strings.Count(rendered, "password"), Equals, 2)
+	c.Check(strings.Count(rendered, "password newpw"), Equals, 1)
 }
 
 func (s *NetrcSuite) TestTrailingCommentSet(c *C) {

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jdx/go-netrc"
@@ -162,6 +163,35 @@ func (s *NetrcSuite) TestPermissive(c *C) {
 	c.Check(f.Machine("m").Get("password"), Equals, "p")
 	body, _ := ioutil.ReadFile(f.Path)
 	c.Check(f.Render(), Equals, string(body))
+}
+
+func (s *NetrcSuite) TestCommentLines(c *C) {
+	f, err := netrc.Parse("./examples/comments.netrc")
+	c.Assert(err, IsNil)
+	c.Check(f.Machine("m").Get("login"), Equals, "l")
+	c.Check(f.Machine("m").Get("password"), Equals, "p")
+	c.Check(f.Machine("n").Get("login"), Equals, "ln")
+	c.Check(f.Machine("n").Get("password"), Equals, "pn")
+	body, _ := ioutil.ReadFile(f.Path)
+	c.Check(f.Render(), Equals, string(body))
+}
+
+func (s *NetrcSuite) TestSetWithCommentLines(c *C) {
+	f, err := netrc.Parse("./examples/comments.netrc")
+	c.Assert(err, IsNil)
+	f.Machine("m").Set("password", "newpw")
+	c.Check(f.Machine("m").Get("password"), Equals, "newpw")
+	rendered := f.Render()
+	c.Check(strings.Contains(rendered, "# comment before any property"), Equals, true)
+	c.Check(strings.Contains(rendered, "# comment between properties"), Equals, true)
+}
+
+func (s *NetrcSuite) TestTrailingCommentSet(c *C) {
+	f, err := netrc.Parse("./examples/login.netrc")
+	c.Assert(err, IsNil)
+	f.Machine("api.heroku.com").Set("login", "newuser")
+	c.Check(f.Machine("api.heroku.com").Get("login"), Equals, "newuser")
+	c.Check(strings.Contains(f.Render(), "# this is my username"), Equals, true)
 }
 
 func (s *NetrcSuite) TestParseString(c *C) {

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -194,6 +194,17 @@ func (s *NetrcSuite) TestTrailingCommentSet(c *C) {
 	c.Check(strings.Contains(f.Render(), "# this is my username"), Equals, true)
 }
 
+func (s *NetrcSuite) TestSetHashLeadingValue(c *C) {
+	f, err := netrc.Parse("./examples/login.netrc")
+	c.Assert(err, IsNil)
+	m := f.Machine("api.heroku.com")
+	m.Set("password", "#secret")
+	c.Check(m.Get("password"), Equals, "#secret")
+	m.Set("password", "#another")
+	c.Check(m.Get("password"), Equals, "#another")
+	c.Check(strings.Count(f.Render(), "password"), Equals, 1)
+}
+
 func (s *NetrcSuite) TestParseString(c *C) {
 	file, err := os.Open("./examples/good.netrc")
 	defer file.Close()


### PR DESCRIPTION
Machine.Get and Machine.Set walked m.tokens by a fixed stride of 4, which desynced when the lexer emitted the extra leading-whitespace and comment-plus-trailing-whitespace tokens produced by a comment on its own line. Walk by skipping whitespace-and-comment tokens and pairing keys with the next non-skippable token instead.

Closes #16