### PR TITLE
feat: support quoted values in netrc fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ machine example.com
 ```
 
 The following escape sequences are supported inside a quoted value: `\"`, `\\`,
-`\n`, `\r`, `\t`. `Get` returns the decoded value, so callers see plain
-strings. `Set` and `AddMachine` automatically quote and escape the value when
-needed; values without whitespace or special characters are written bare so
-existing files round-trip unchanged.
+`\n`, `\r`, `\t`. Any other `\x` is preserved literally on decode so
+hand-edited values are never silently corrupted. `Get` returns the decoded
+value, so callers see plain strings. `Set` and `AddMachine` automatically
+quote and escape the value when needed; values without whitespace or special
+characters are written bare so existing files round-trip unchanged.
 
 This matches the quoting syntax adopted by curl 7.84+. Older `.netrc` parsers
 may not recognize quoted values, so portability across tools varies.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,23 @@ n, err := netrc.Parse(filepath.Join(usr.HomeDir, ".netrc"))
 n.Machine("api.heroku.com").Set("password", "newapikey")
 n.Save()
 ```
+
+# Quoting
+
+Values that contain whitespace, double quotes, or backslashes can be wrapped in
+double quotes:
+
+```
+machine example.com
+  login alice
+  password "my pass with spaces"
+```
+
+The following escape sequences are supported inside a quoted value: `\"`, `\\`,
+`\n`, `\r`, `\t`. `Get` returns the decoded value, so callers see plain
+strings. `Set` and `AddMachine` automatically quote and escape the value when
+needed; values without whitespace or special characters are written bare so
+existing files round-trip unchanged.
+
+This matches the quoting syntax adopted by curl 7.84+. Older `.netrc` parsers
+may not recognize quoted values, so portability across tools varies.

--- a/examples/escaped.netrc
+++ b/examples/escaped.netrc
@@ -1,0 +1,4 @@
+# password with escaped characters
+machine escaped.example.com
+  login alice
+  password "say \"hi\"\nthere"

--- a/examples/spaces.netrc
+++ b/examples/spaces.netrc
@@ -1,0 +1,4 @@
+# password with spaces
+machine spaces.example.com
+  login alice
+  password "my pass with spaces"

--- a/netrc.go
+++ b/netrc.go
@@ -87,7 +87,7 @@ func (n *Netrc) AddMachine(name, login, password string) {
 		n.machines = append(n.machines, machine)
 	}
 	machine.Name = name
-	machine.tokens = []string{"machine ", name, "\n"}
+	machine.tokens = []string{"machine ", quoteIfNeeded(name), "\n"}
 	machine.Set("login", login)
 	machine.Set("password", password)
 }
@@ -163,6 +163,21 @@ func lex(file io.Reader) []string {
 		if eof && len(data) == 0 {
 			return 0, nil, nil
 		}
+		if data[0] == '"' {
+			for i := 1; i < len(data); i++ {
+				if data[i] == '\\' && i+1 < len(data) {
+					i++
+					continue
+				}
+				if data[i] == '"' {
+					return i + 1, data[:i+1], nil
+				}
+			}
+			if eof {
+				return len(data), data, nil
+			}
+			return 0, nil, nil
+		}
 		inWhitespace := unicode.IsSpace(rune(data[0]))
 		for i, c := range data {
 			if c == '#' {
@@ -218,7 +233,7 @@ func parse(tokens []string) (*Netrc, error) {
 				machine.IsDefault = true
 				machine.Name = "default"
 			} else {
-				machine.Name = tokens[i+2]
+				machine.Name = unquote(tokens[i+2])
 			}
 		}
 		if machine == nil {
@@ -241,24 +256,99 @@ func (m *Machine) Get(name string) string {
 			return ""
 		}
 		if m.tokens[i] == name {
-			return m.tokens[i+2]
+			return unquote(m.tokens[i+2])
 		}
 		i = i + 4
 	}
 }
 
+// unquote decodes a possibly-quoted netrc value. A quoted value is wrapped in
+// double quotes and may contain the escapes \", \\, \n, \r, \t. Unrecognized
+// escapes drop the backslash. A bare value is returned unchanged.
+func unquote(value string) string {
+	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+		return value
+	}
+	inner := value[1 : len(value)-1]
+	var b strings.Builder
+	b.Grow(len(inner))
+	for i := 0; i < len(inner); i++ {
+		c := inner[i]
+		if c != '\\' || i+1 >= len(inner) {
+			b.WriteByte(c)
+			continue
+		}
+		i++
+		switch inner[i] {
+		case 'n':
+			b.WriteByte('\n')
+		case 'r':
+			b.WriteByte('\r')
+		case 't':
+			b.WriteByte('\t')
+		case '"', '\\':
+			b.WriteByte(inner[i])
+		default:
+			b.WriteByte(inner[i])
+		}
+	}
+	return b.String()
+}
+
 // Set a property on the machine
 func (m *Machine) Set(name, value string) {
+	encoded := quoteIfNeeded(value)
 	i := 4
 	if m.IsDefault {
 		i = 2
 	}
 	for i+2 < len(m.tokens) {
 		if m.tokens[i] == name {
-			m.tokens[i+2] = value
+			m.tokens[i+2] = encoded
 			return
 		}
 		i = i + 4
 	}
-	m.tokens = append(m.tokens, "  ", name, " ", value, "\n")
+	m.tokens = append(m.tokens, "  ", name, " ", encoded, "\n")
+}
+
+// quoteIfNeeded returns value as a netrc token. Values containing whitespace,
+// double quotes, or backslashes are wrapped in double quotes and escaped using
+// curl-compatible escapes (\", \\, \n, \r, \t). Other values pass through
+// unchanged so files with simple credentials round-trip byte-for-byte.
+func quoteIfNeeded(value string) string {
+	if !needsQuoting(value) {
+		return value
+	}
+	var b strings.Builder
+	b.Grow(len(value) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(value); i++ {
+		switch c := value[i]; c {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteByte(c)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+func needsQuoting(value string) bool {
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case ' ', '\t', '\n', '\r', '"', '\\':
+			return true
+		}
+	}
+	return false
 }

--- a/netrc.go
+++ b/netrc.go
@@ -87,7 +87,7 @@ func (n *Netrc) AddMachine(name, login, password string) {
 		n.machines = append(n.machines, machine)
 	}
 	machine.Name = name
-	machine.tokens = []string{"machine ", quoteIfNeeded(name), "\n"}
+	machine.tokens = []string{"machine", " ", quoteIfNeeded(name), "\n"}
 	machine.Set("login", login)
 	machine.Set("password", password)
 }
@@ -263,8 +263,10 @@ func (m *Machine) Get(name string) string {
 }
 
 // unquote decodes a possibly-quoted netrc value. A quoted value is wrapped in
-// double quotes and may contain the escapes \", \\, \n, \r, \t. Unrecognized
-// escapes drop the backslash. A bare value is returned unchanged.
+// double quotes and may contain the escapes \", \\, \n, \r, \t. For any other
+// \x sequence the backslash is preserved literally so hand-edited values like
+// "\q" round-trip as \q rather than being silently corrupted to q. A bare
+// value is returned unchanged.
 func unquote(value string) string {
 	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
 		return value
@@ -289,6 +291,7 @@ func unquote(value string) string {
 		case '"', '\\':
 			b.WriteByte(inner[i])
 		default:
+			b.WriteByte('\\')
 			b.WriteByte(inner[i])
 		}
 	}
@@ -309,7 +312,13 @@ func (m *Machine) Set(name, value string) {
 		}
 		i = i + 4
 	}
-	m.tokens = append(m.tokens, "  ", name, " ", encoded, "\n")
+	// Property not present: extend the previous trailing whitespace with the
+	// indent for the new entry so the appended block lands at the next stride
+	// boundary that Get expects.
+	if n := len(m.tokens); n > 0 && strings.HasSuffix(m.tokens[n-1], "\n") {
+		m.tokens[n-1] += "  "
+	}
+	m.tokens = append(m.tokens, name, " ", encoded, "\n")
 }
 
 // quoteIfNeeded returns value as a netrc token. Values containing whitespace,
@@ -321,7 +330,7 @@ func quoteIfNeeded(value string) string {
 		return value
 	}
 	var b strings.Builder
-	b.Grow(len(value) + 2)
+	b.Grow(2*len(value) + 2)
 	b.WriteByte('"')
 	for i := 0; i < len(value); i++ {
 		switch c := value[i]; c {

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -164,6 +164,64 @@ func (s *NetrcSuite) TestPermissive(c *C) {
 	c.Check(f.Render(), Equals, string(body))
 }
 
+func (s *NetrcSuite) TestPasswordWithSpaces(c *C) {
+	f, err := netrc.Parse("./examples/spaces.netrc")
+	c.Assert(err, IsNil)
+	m := f.Machine("spaces.example.com")
+	c.Check(m.Get("login"), Equals, "alice")
+	c.Check(m.Get("password"), Equals, "my pass with spaces")
+	body, _ := ioutil.ReadFile(f.Path)
+	c.Check(f.Render(), Equals, string(body))
+}
+
+func (s *NetrcSuite) TestPasswordWithEscapes(c *C) {
+	f, err := netrc.Parse("./examples/escaped.netrc")
+	c.Assert(err, IsNil)
+	m := f.Machine("escaped.example.com")
+	c.Check(m.Get("login"), Equals, "alice")
+	c.Check(m.Get("password"), Equals, "say \"hi\"\nthere")
+	body, _ := ioutil.ReadFile(f.Path)
+	c.Check(f.Render(), Equals, string(body))
+}
+
+func (s *NetrcSuite) TestSetPasswordWithSpaces(c *C) {
+	f, err := netrc.Parse("./examples/login.netrc")
+	c.Assert(err, IsNil)
+	heroku := f.Machine("api.heroku.com")
+	heroku.Set("password", "my new pass")
+	c.Check(heroku.Get("password"), Equals, "my new pass")
+	c.Check(f.Render(), Equals, "# this is my login netrc\nmachine api.heroku.com\n  login jeff@heroku.com # this is my username\n  password \"my new pass\"\n")
+}
+
+func (s *NetrcSuite) TestSetPasswordWithQuoteAndNewline(c *C) {
+	dir := c.MkDir()
+	n := netrc.New(filepath.Join(dir, ".netrc"))
+	n.AddMachine("m", "alice", "ab\"c\nd")
+	rendered := n.Render()
+	c.Check(rendered, Equals, "machine m\n  login alice\n  password \"ab\\\"c\\nd\"\n")
+	round, err := netrc.ParseString(rendered)
+	c.Assert(err, IsNil)
+	c.Check(round.Machine("m").Get("password"), Equals, "ab\"c\nd")
+}
+
+func (s *NetrcSuite) TestSetPasswordNoQuoteWhenSafe(c *C) {
+	f, err := netrc.Parse("./examples/login.netrc")
+	c.Assert(err, IsNil)
+	heroku := f.Machine("api.heroku.com")
+	heroku.Set("password", "plain")
+	c.Check(f.Render(), Equals, "# this is my login netrc\nmachine api.heroku.com\n  login jeff@heroku.com # this is my username\n  password plain\n")
+}
+
+func (s *NetrcSuite) TestAddMachineWithSpaces(c *C) {
+	dir := c.MkDir()
+	n := netrc.New(filepath.Join(dir, ".netrc"))
+	n.AddMachine("m", "user", "pass with spaces")
+	round, err := netrc.ParseString(n.Render())
+	c.Assert(err, IsNil)
+	c.Check(round.Machine("m").Get("login"), Equals, "user")
+	c.Check(round.Machine("m").Get("password"), Equals, "pass with spaces")
+}
+
 func (s *NetrcSuite) TestParseString(c *C) {
 	file, err := os.Open("./examples/good.netrc")
 	defer file.Close()

--- a/netrc_test.go
+++ b/netrc_test.go
@@ -216,6 +216,8 @@ func (s *NetrcSuite) TestAddMachineWithSpaces(c *C) {
 	dir := c.MkDir()
 	n := netrc.New(filepath.Join(dir, ".netrc"))
 	n.AddMachine("m", "user", "pass with spaces")
+	c.Check(n.Machine("m").Get("login"), Equals, "user")
+	c.Check(n.Machine("m").Get("password"), Equals, "pass with spaces")
 	round, err := netrc.ParseString(n.Render())
 	c.Assert(err, IsNil)
 	c.Check(round.Machine("m").Get("login"), Equals, "user")


### PR DESCRIPTION
Adds curl 7.84+ compatible quoting so values containing whitespace, double quotes, or backslashes can be wrapped in `"..."` with the escapes `\"`, `\\`, `\n`, `\r`, `\t`. `Get` decodes the value and `Set`/`AddMachine` auto-quote only when needed, leaving simple values bare so existing files round-trip unchanged.

Closes #13